### PR TITLE
Fix three paired-end preprocessing bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clustering bugs**: Fixed wrong strand flag for second segment, duplicate refid comparison, operator precedence in overlap check, and removed shadowed variables ([#10](https://github.com/riasc/RNAnue/issues/10), [#19](https://github.com/riasc/RNAnue/pull/19))
 - **ScoringMatrix memory**: Replaced C-style malloc/calloc/free with RAII vectors, fixed inner-loop heap allocation leak, replaced nested `std::map` scoring lookup with `switch` ([#5](https://github.com/riasc/RNAnue/issues/5), [#20](https://github.com/riasc/RNAnue/pull/20))
 - **IBPTree leaks and crash**: Added destructor to free all nodes and intervals, fixed `search()` segfault on unknown chromosome, initialized uninitialized pointer ([#6](https://github.com/riasc/RNAnue/issues/6), [#21](https://github.com/riasc/RNAnue/pull/21))
+- **Paired-end preprocessing**: Fixed reverse read quality never checked, window trimming overwriting forward boundary instead of reverse, and data race on read counter ([#9](https://github.com/riasc/RNAnue/issues/9), [#22](https://github.com/riasc/RNAnue/pull/22))
 
 ## Refactored
 

--- a/src/Preproc.cpp
+++ b/src/Preproc.cpp
@@ -1,5 +1,7 @@
 #include "Preproc.hpp"
 
+#include <atomic>
+
 // constructor to process single-end reads
 Preproc::Preproc(po::variables_map& params, StateTransition& adpt5Tables, StateTransition& adpt3Tables)
     : params(params), adpt5Tables(adpt5Tables), adpt3Tables(adpt3Tables) {
@@ -21,7 +23,7 @@ void Preproc::processing(fs::path& in, fs::path& out) {
     seqan3::sequence_file_input fin{in.string()};
     seqan3::sequence_file_output fout{out.string()};
 
-    int readcount = 0;
+    std::atomic<int> readcount{0};
     auto reads = fin | seqan3::views::async_input_buffer(100);
     auto worker = [&]()
     {
@@ -84,7 +86,7 @@ void Preproc::processing(fs::path& inFwd, fs::path& outFwd, fs::path& inRev, fs:
 
     std::mutex outMutex, progressMutex;
 
-    int readcount = 0;
+    std::atomic<int> readcount{0};
     auto inFwdSeqBuf = inFwdSeq | seqan3::views::async_input_buffer(100);
     auto inRevSeqBuf = inRevSeq | seqan3::views::async_input_buffer(100);
     auto worker = [&]() {
@@ -110,7 +112,7 @@ void Preproc::processing(fs::path& inFwd, fs::path& outFwd, fs::path& inRev, fs:
             std::pair<size_t, size_t> bndsRev = trimReads(seqRev);
             if (params["wtrim"].as<std::bitset<1>>() == std::bitset<1>("1")) {
                 bndsFwd.second = nibble(qualFwd, bndsFwd);
-                bndsFwd.second = nibble(qualRev, bndsRev);
+                bndsRev.second = nibble(qualRev, bndsRev);
             }
 
             // retrieve trimmed sequences
@@ -125,7 +127,7 @@ void Preproc::processing(fs::path& inFwd, fs::path& outFwd, fs::path& inRev, fs:
 
             // perform filtering (quality and length)
             bool fwdFilter = filterReads(trmQualFwd);
-            bool revFilter = filterReads(trmQualFwd);
+            bool revFilter = filterReads(trmQualRev);
 
             if(fwdFilter && revFilter) {
                 std::pair<dtp::DNAVector, dtp::QualVector> merged = mergeReads(trmSeqFwd, trmQualFwd,


### PR DESCRIPTION
## Summary
### Fixed
- **Reverse read quality**: `filterReads()` was called with `trmQualFwd` for both reads — reverse reads with poor quality passed through unfiltered (#9)
- **Window trimming**: `nibble()` result for reverse read overwrote `bndsFwd.second` instead of `bndsRev.second`, corrupting forward boundary and skipping reverse trimming (#9)
- **Data race**: `readcount` (plain `int`) incremented from multiple threads without synchronization — now `std::atomic<int>` (#9)

Closes #9

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Docker image builds successfully (CI)
- [x] All tests pass across GCC 12/13/14 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)